### PR TITLE
Fixed gradle build

### DIFF
--- a/build/gradle/wrapper/gradle-wrapper.properties
+++ b/build/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-2.1-bin.zip


### PR DESCRIPTION
Fixed gradle build error caused by HTTPS being required by repositories. Gradle 2.1 added HTTPS by default so this fixes the issue.